### PR TITLE
OPS-3938 Specify variables types explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ The following resources _CAN_ be created:
 | name | The name used to interpolate into the resources created | string | n/a | yes |
 | certificate\_arn | The arn of the certificate | string | `""` | no |
 | cidr | The cidr used for the network | string | `"172.30.0.0/16"` | no |
-| extra\_ssl\_certs | The extra ssl certifice arns applied to the SSL Listener | list | `[]` | no |
-| extra\_ssl\_certs\_count | The count of the extra_ssl_certs | string | `"0"` | no |
-| https\_enabled | Do we enable https | string | `"false"` | no |
+| extra\_ssl\_certs | The extra ssl certifice arns applied to the SSL Listener | set(string) | `[]` | no |
+| extra\_ssl\_certs\_count | The count of the extra_ssl_certs | number | `"0"` | no |
+| https\_enabled | Do we enable https | bool | `"false"` | no |
 | lb\_ip\_address\_type | The `ip_address_type` of the LB, either 'ipv4' or 'dualstack' in case ipv6 needs to be supported as well | string | `"ipv4"` | no |
-| redirect\_rules | A list with maps populated with redirect rules | list | `[]` | no |
+| redirect\_rules | A list with maps populated with redirect rules | list(map(string)) | `[]` | no |
 | response\_code | The default status code to return when no rules have been met | string | `"500"` | no |
 | response\_message\_body | The default response message body in case no rules have been met | string | `"No match"` | no |
-| tags | Extra tags to be applied to the resources | map | `{}` | no |
+| tags | Extra tags to be applied to the resources | map(string) | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The following resources _CAN_ be created:
 | name | The name used to interpolate into the resources created | string | n/a | yes |
 | certificate\_arn | The arn of the certificate | string | `""` | no |
 | cidr | The cidr used for the network | string | `"172.30.0.0/16"` | no |
-| extra\_ssl\_certs | The extra ssl certifice arns applied to the SSL Listener | set(string) | `[]` | no |
+| extra\_ssl\_certs | The extra ssl certifice arns applied to the SSL Listener | list(string) | `[]` | no |
 | extra\_ssl\_certs\_count | The count of the extra_ssl_certs | number | `"0"` | no |
 | https\_enabled | Do we enable https | bool | `"false"` | no |
 | lb\_ip\_address\_type | The `ip_address_type` of the LB, either 'ipv4' or 'dualstack' in case ipv6 needs to be supported as well | string | `"ipv4"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -1,52 +1,63 @@
 variable "name" {
+  type        = string
   description = "The name used to interpolate into the resources created"
 }
 variable "cidr" {
+  type        = string
   default     = "172.30.0.0/16"
   description = "The cidr used for the network"
 }
 
 variable "tags" {
+  type        = map(string)
   default     = {}
   description = "Extra tags to be applied to the resources"
 }
 
 variable "https_enabled" {
+  type        = bool
   default     = false
   description = "Do we enable https"
 }
 
 variable "certificate_arn" {
+  type        = string
   default     = ""
   description = "The arn of the certificate"
 }
 
 variable "extra_ssl_certs" {
+  type        = set(string)
   default     = []
   description = "The extra ssl certifice arns applied to the SSL Listener"
 }
 
 variable "extra_ssl_certs_count" {
+  type        = number
   default     = 0
   description = "The count of the extra_ssl_certs"
 }
 
 variable "redirect_rules" {
+  type        = list(map(string))
   default     = []
   description = "A list with maps populated with redirect rules"
 }
 
 variable "lb_ip_address_type" {
+  type        = string
   default     = "ipv4"
   description = "The `ip_address_type` of the LB, either 'ipv4' or 'dualstack' in case ipv6 needs to be supported as well"
 }
 
 variable "response_message_body" {
+  type        = string
   default     = "No match"
   description = "The default response message body in case no rules have been met"
 }
 
 variable "response_code" {
+  type        = string
   default     = "500"
   description = "The default status code to return when no rules have been met"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "certificate_arn" {
 }
 
 variable "extra_ssl_certs" {
-  type        = set(string)
+  type        = list(string)
   default     = []
   description = "The extra ssl certifice arns applied to the SSL Listener"
 }


### PR DESCRIPTION
This prevents this module to be properly used together with terragrunt.